### PR TITLE
docs: Fix simple typo, ommitted -> omitted

### DIFF
--- a/pyramid_sessions/session_manager.py
+++ b/pyramid_sessions/session_manager.py
@@ -33,7 +33,7 @@ class SessionManager(object):
     def get(self, name=None):
         """
         Return session factory object if found. Returns the default session
-        if `name` is ommitted.
+        if `name` is omitted.
         """
         if not name:
             return self._init_factory(self.default_session)


### PR DESCRIPTION
There is a small typo in pyramid_sessions/session_manager.py.

Should read `omitted` rather than `ommitted`.

